### PR TITLE
Fix computing MSE loss function

### DIFF
--- a/helmnet/hybridnet.py
+++ b/helmnet/hybridnet.py
@@ -257,7 +257,7 @@ class IterativeSolver(pl.LightningModule):
 
     def loss_function(self, x):
         if self.hparams.loss == "mse":
-            return x.pow(2).mean((1, 2, 3))
+            return x.pow(2).mean()
         else:
             raise NotImplementedError(
                 "The loss function {} is not implemented".format(self.hparams.loss)


### PR DESCRIPTION
I think that the MSE loss function computes the mean over all dimensions (batch, x, y), so there's no need to specify the dimensions (but I might be wrong).