### PR TITLE
Fix setting the invalid losses to "inf"

### DIFF
--- a/helmnet/hybridnet.py
+++ b/helmnet/hybridnet.py
@@ -298,7 +298,7 @@ class IterativeSolver(pl.LightningModule):
             # Get loss
             loss = self.loss_function(output["residuals"][-1]).sqrt()
             # NaNs to Infs, due to Lightning bug: https://github.com/PyTorchLightning/pytorch-lightning/issues/2636
-            loss[torch.isnan(loss)] = torch.isnan(loss).float() * float("inf")
+            loss[torch.isnan(loss)] = float("inf")
         sample_wavefield = (hardtanh(output["wavefields"][0][0]) + 1) / 2
         return {
             "loss": loss,


### PR DESCRIPTION
The propagation of values was wrong.
E.g. loss = [1, 2, NaN, 3, NaN] -> isnan(loss) == [False, False, True, False, True]

Thus loss[isnan(loss)] would have shape (2, ), however isnan(loss) would have shape (5, ).

PyTorch supports propagating a scaler into tensor.